### PR TITLE
Remove misleading note about V8 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ const propCount = Object.keys(this.props).length;
 
 Replacing these patterns with a native and optimized counting method significantly reduces memory overhead, garbage collection, and as such, runtime performance impacts.
 
-The implementation in V8 seems quite straight forward, due to the already existing [GetPropertyNames](https://github.com/v8/v8/blob/2b13b925298112a1366f721c8d30c96b8b61aeae/include/v8-object.h#L402-L405) API.
-
 ### Concrete usage examples
 
 I only searched for `Object.keys().length`, since that is the most common one.


### PR DESCRIPTION
The implementation of the linked `GetPropertyNames` API in v8 does the very thing this proposal wants to avoid - allocating a JS array: https://github.com/v8/v8/blob/2b13b925298112a1366f721c8d30c96b8b61aeae/src/api/api.cc#L4800

Additionally I find pointing out an API in a single engine inappropriate, the standard does not cater to any particular implementations. If it is relevant to the proposal please cover a larger part of the engine ecosystem.