### PR TITLE
Stage 2 preparation

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -5,47 +5,37 @@
 <script src="./spec.js"></script>
 <pre class="metadata">
 title: Object.propertyCount
-stage: 0
+stage: 1
 contributors: Ruben Bridgewater, Jordan Harband
 </pre>
 
-<emu-clause id="sec-fundamental-objects" number="20">
-  <h1>Fundamental Objects</h1>
-
-  <emu-clause id="sec-object-objects">
-    <h1>Object Objects</h1>
-
-    <emu-clause id="sec-properties-of-the-object-constructor" number="2">
-      <h1>Properties of the Object Constructor</h1>
-
-      <emu-clause id="sec-object.propertycount" number="20">
-        <h1>Object.propertyCount ( _target_ [ , _options_ ] )</h1>
-        <p>When the `Object.propertyCount` method is called, the following steps are taken:</p>
-        <emu-alg>
-          1. If _target_ is not an Object, throw a TypeError exception.
-          1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
-          1. Let _keyTypes_ be CreateArrayFromList(« *"index"*, *"nonIndexString"* »).
-          1. Let _keyTypesOption_ be ? Get(_resolvedOptions_, *"keyTypes"*).
-          1. If _keyTypesOption_ is not *undefined*, then
-              1. If _keyTypesOption_ is not an Object, throw a TypeError exception.
-              1. Set _keyTypes_ to ? CreateListFromArrayLike(_keyTypesOption_).
-              1. If _keyTypes_ contains any value other than *"index"*, *"nonIndexString"*, or *"symbol"*, or if any of those values are repeated, throw a TypeError exception.
-          1. Let _enumerable_ be ? Get(_resolvedOptions_, *"enumerable"*).
-          1. If _enumerable_ is *undefined*, set _enumerable_ to *true*.
-          1. If _enumerable_ is not one of *true*, *false*, or *"all"*, throw a TypeError exception.
-          1. Let _count_ be 0.
-          1. Let _ownKeys_ be _target_.[[OwnPropertyKeys]]().
-          1. For each element _key_ of _ownKeys_, do
-              1. Let _desc_ be ? _target_.[[GetOwnProperty]](_key_).
-              1. If _desc_ is not *undefined*, and either _enumerable_ is *"all"* or _enumerable_ is _desc_.[[Enumerable]], then
-                1. If _key_ is a Symbol and _keyTypes_ contains *"symbol"*, increment _count_ by 1.
-                1. Else if _key_ is an array index and _keyTypes_ contains *"index"*, increment _count_ by 1.
-                1. Else if _keyTypes_ contains *"nonIndexString"*, increment _count_ by 1.
-          1. Return _count_.
-        </emu-alg>
-      </emu-clause>
-    </emu-clause>
-  </emu-clause>
+<emu-clause id="sec-demo-clause">
+  <h1>Object.propertyCount ( _target_ [ , _options_ ] )</h1>
+  <p>When the `Object.propertyCount` method is called, the following steps are taken:</p>
+  <emu-alg>
+    1. If _target_ is not an Object, throw a TypeError exception.
+    1. Let _resolvedOptions_ be ? GetOptionsObject(_options_).
+    1. Let _keyTypes_ be ? Get(_resolvedOptions_, *"keyTypes"*).
+    1. If _keyTypes_ is *undefined*, then
+        1. Set _keyTypes_ to CreateArrayFromList(« *"string"* »).
+    1. Else, perform the following,
+        1. If _keyTypes_ is not an Object, throw a TypeError exception.
+        1. Set _keyTypes_ to ? CreateListFromArrayLike(_keyTypes_, ~all~).
+        1. If _keyTypes_ contains any value other than *"string"*, or *"symbol"*, throw a TypeError exception.
+    1. Let _enumerable_ be ? Get(_resolvedOptions_, *"enumerable"*).
+    1. If _enumerable_ is *undefined*, set _enumerable_ to *true*.
+    1. Else if _enumerable_ is not one of *true*, *false*, or *"all"*, throw a TypeError exception.
+    1. Let _count_ be 0.
+    1. Let _ownKeys_ be _target_.[[OwnPropertyKeys]]().
+    1. For each element _key_ of _ownKeys_, perform the following steps, do
+        1. Let _desc_ be _target_.[[GetOwnProperty]](_key_).
+        1. If _desc_ is not *undefined*, then
+            1. If _enumerable_ is not *"all"*, then
+                1. If _enumerable_ is not equal to _desc_.[[Enumerable]], continue to the next _key_.
+            1. If _key_ is a Symbol and _keyTypes_ contains *"symbol"*, increment _count_ by 1.
+            1. If _key_ is a String and _keyTypes_ contains *"string"*, increment _count_ by 1.
+    1. Return 𝔽(_count_).
+  </emu-alg>
 </emu-clause>
 
 <!-- Copied from ECMA-402 GetOptionsObject -->


### PR DESCRIPTION
This removes the index and nonIndexString keyTypes and instead uses string as only type.

In addition it highlights a couple of words, and aligns the stage proposal and the champions in all spots.

It also adds a section to highlight precedent about arrays containing non-index-string keys.